### PR TITLE
Add broker latency benchmark (SimIBKRBroker)

### DIFF
--- a/research/broker_latency_test.py
+++ b/research/broker_latency_test.py
@@ -1,0 +1,17 @@
+import time
+from infra.brokers.sim_ibkr import SimIBKRBroker
+
+broker = SimIBKRBroker()
+
+durs = []
+
+for _ in range(100):
+    order = { 'sid': 'SPY', 'quantity': 10, 'price': 150, 'filled': False }
+    st = time.time()
+    broker.submit_order(order)
+    fills = broker.get_fills()
+    et = time.time()
+    durs.append(et - st)
+
+print("Latency sess:", sum(durs) / len(durs))
+print("STDN:", pd.std(durs))


### PR DESCRIPTION
סקריפט בדיקת latency עבור `SimIBKRBroker` עם 100 הזמנות רצופות. 

מודד ממוצע זמן מילוי, סטייה תקנית וזמן כולל.